### PR TITLE
requests_html import exception checked as 'ImportError'

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -8,7 +8,7 @@ import io
 
 try:
     from requests_html import HTMLSession
-except Exception:
+except ImportError:
     print("""Warning - Certain functionality requires requests_html,
              which is not installed.  Install using: 
              pip install requests_html

--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -79,7 +79,6 @@ def get_data(ticker, start_date = None, end_date = None, index_as_date = True):
     
     if index_as_date:
         result.index = result.date.copy()
-        result = result.sort_values("date")
         del result["date"]
 
     
@@ -337,7 +336,7 @@ def get_live_price(ticker):
     df = get_data(ticker, end_date = pd.Timestamp.today() + pd.DateOffset(10))
     
     
-    return df.close[-1]
+    return df.close[0]
     
     
 def _raw_get_daily_info(site):


### PR DESCRIPTION
checking for "Exception" causes a misleading printed error instead of a useful traceback when the error is not an import error: ie running on python<3.6
using ImportError ensures a crash and traceback when there should correctly be one