### PR TITLE
Update _raw_get_daily_info()

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -488,7 +488,7 @@ def _raw_get_daily_info(site):
     
     del df["52 Week Range"]
     
-    df["% Change"] = df["% Change"].map(lambda x: float(x.strip("%")))
+    df["% Change"] = df["% Change"].map(lambda x: float(x.strip("%").replace(',','')))
      
 
     fields_to_change = [x for x in df.columns.tolist() if "Vol" in x \


### PR DESCRIPTION
When attempting to retrieve the top gainers or losers, a percentage containing a comma will produce a ValueError. For example:

ValueError: could not convert string to float: '+6,421.74'

Removing the comma with the replace() function seems to fix the issue.