### PR TITLE
Handle the case where there are earning-report numbers for only one quarter

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -242,7 +242,7 @@ def get_stats(ticker):
 
     tables = pd.read_html(stats_site)
     
-    tables = [table for table in tables if table.shape[1] == 2]
+    tables = [table for table in tables[1:] if table.shape[1] == 2]
     
     table = tables[0]
     for elt in tables[1:]:


### PR DESCRIPTION
Usually the first table has more than 2 columns; each column corresponding to a different quarter. But some stocks such as 'arry' there is only 2 columns and that leads to problem.

Because the first table usually has >2 columns, it gets filtered out by the condition `shape[1] == 2`.

The fix explicitly ignores the first table. 

Fixes #28 