### PR TITLE
Added exceptions for cases in which no balance sheet data is returned

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -764,21 +764,24 @@ def get_earnings(ticker):
        @param: ticker
     '''
 
+    result = {
+        "quarterly_results": pd.DataFrame(),
+        "yearly_revenue_earnings": pd.DataFrame(),
+        "quarterly_revenue_earnings": pd.DataFrame()
+    }
+
     financials_site = "https://finance.yahoo.com/quote/" + ticker + \
-            "/financials?p=" + ticker
-            
+        "/financials?p=" + ticker
+
     json_info = _parse_json(financials_site)
-    
+
+    if "earnings" not in json_info:
+        return result
+
     temp = json_info["earnings"]
-    
+
     if temp == None:
-        return {
-            "quarterly_results": pd.DataFrame(),
-            "yearly_revenue_earnings": pd.DataFrame(),
-            "quarterly_revenue_earnings": pd.DataFrame()
-        }
-    
-    result = {}
+        return result
     
     result["quarterly_results"] = pd.DataFrame.from_dict(temp["earningsChart"]["quarterly"])
     

--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -671,7 +671,7 @@ def get_dividends(ticker, start_date = None, end_date = None, index_as_date = Tr
     
     
     if not resp.ok:
-        raise AssertionError(resp.json())
+        return pd.DataFrame()
         
     
     # get JSON response

--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -372,21 +372,29 @@ def _parse_json(url):
 
     json_str = html.split('root.App.main =')[1].split(
         '(this)')[0].split(';\n}')[0].strip()
-    data = json.loads(json_str)[
-        'context']['dispatcher']['stores']['QuoteSummaryStore']
+    
+    try:
+        data = json.loads(json_str)[
+            'context']['dispatcher']['stores']['QuoteSummaryStore']
+    except:
+        return '{}'
+    else:
+        # return data
+        new_data = json.dumps(data).replace('{}', 'null')
+        new_data = re.sub(r'\{[\'|\"]raw[\'|\"]:(.*?),(.*?)\}', r'\1', new_data)
 
-    # return data
-    new_data = json.dumps(data).replace('{}', 'null')
-    new_data = re.sub(r'\{[\'|\"]raw[\'|\"]:(.*?),(.*?)\}', r'\1', new_data)
+        json_info = json.loads(new_data)
 
-    json_info = json.loads(new_data)
-
-    return json_info
+        return json_info
 
 
 def _parse_table(json_info):
 
     df = pd.DataFrame(json_info)
+    
+    if df.empty:
+        return df
+    
     del df["maxAge"]
 
     df.set_index("endDate", inplace=True)
@@ -431,10 +439,13 @@ def get_balance_sheet(ticker, yearly = True):
 
     json_info = _parse_json(balance_sheet_site)
     
-    if yearly:
-        temp = json_info["balanceSheetHistory"]["balanceSheetStatements"]
-    else:
-        temp = json_info["balanceSheetHistoryQuarterly"]["balanceSheetStatements"]
+    try:
+        if yearly:
+            temp = json_info["balanceSheetHistory"]["balanceSheetStatements"]
+        else:
+            temp = json_info["balanceSheetHistoryQuarterly"]["balanceSheetStatements"]
+    except:
+        temp = []
         
     return _parse_table(temp)      
 

--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -678,8 +678,8 @@ def get_dividends(ticker, start_date = None, end_date = None, index_as_date = Tr
     data = resp.json()
     
     # check if there is data available for dividends
-    if "dividends" not in data["chart"]["result"][0]['events']:
-        raise AssertionError("There is no data available on dividends, or none have been granted")
+    if "events" not in data["chart"]["result"][0] or "dividends" not in data["chart"]["result"][0]['events']:
+        return pd.DataFrame()
     
     # get the dividend data
     frame = pd.DataFrame(data["chart"]["result"][0]['events']['dividends'])
@@ -770,6 +770,13 @@ def get_earnings(ticker):
     json_info = _parse_json(financials_site)
     
     temp = json_info["earnings"]
+    
+    if temp == None:
+        return {
+            "quarterly_results": pd.DataFrame(),
+            "yearly_revenue_earnings": pd.DataFrame(),
+            "quarterly_revenue_earnings": pd.DataFrame()
+        }
     
     result = {}
     


### PR DESCRIPTION
`get_balance_sheet` was not working anymore with some tickers. 
The problem is that the APIs are no longer returning any data if there is no data for a given company.
Try for example AACQ or ACIA
The issue can be generated at two different stages: when parsing JSON, because the key `QuoteSummaryStore` does not exist (see ACIA), or because empty data is passed to `_parse_table` (see AACQ).

EDIT

Added checks for empty data also on `get_dividends` and `get_earnings`.

In `get_dividends` when no dividends are found instead of the exception can we simply return an empty DataFrame? This makes it easier to use `get_dividends` inside a "loop"