### PR TITLE
Fix issue handling 'nan' floats in get_top_crypto.

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -625,9 +625,9 @@ def get_top_crypto():
     df = tables[0].copy()
 
     
-    df["% Change"] = df["% Change"].map(lambda x: float(x.strip("%").\
-                                                          strip("+").\
-                                                          replace(",", "")))
+    df["% Change"] = df["% Change"].map(lambda x: float(str(x).strip("%").\
+                                                               strip("+").\
+                                                               replace(",", "")))
     del df["52 Week Range"]
     del df["1 Day Chart"]
     
@@ -637,7 +637,7 @@ def get_top_crypto():
     for field in fields_to_change:
         
         if type(df[field][0]) == str:
-            df[field] = df[field].map(_convert_to_numeric)
+            df[field] = df[field].map(lambda x: _convert_to_numeric(str(x)))
             
             
     session.close()        


### PR DESCRIPTION
Sometimes nan's are returned instead of strings when converting the html page to a table in the `get_top_crypto` method.

This patch forces everything to a string for the '% Change' column.

Please note that the line endings in this PR may be inconsistent with the original file.
