### PR TITLE
Fix no income statements availible with exception handling.

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -417,11 +417,13 @@ def get_income_statement(ticker, yearly = True):
             "/financials?p=" + ticker
 
     json_info = _parse_json(income_site)
-    
-    if yearly:
-        temp = json_info["incomeStatementHistory"]["incomeStatementHistory"]
-    else:
-        temp = json_info["incomeStatementHistoryQuarterly"]["incomeStatementHistory"]
+    try:
+        if yearly:
+            temp = json_info["incomeStatementHistory"]["incomeStatementHistory"]
+        else:
+            temp = json_info["incomeStatementHistoryQuarterly"]["incomeStatementHistory"]
+    except:
+        temp = []
     
     return _parse_table(temp)      
         


### PR DESCRIPTION
Resolves #73 

Some tickers dont have an income statements availible, as they do not represent companies but e.g. ETFs.
Catching the resulting exception in the same way as in `get_balance_sheet` is much nicer.