### PR TITLE
Added method for decryption of encrypted blob coming back from yahoo finance in _parse_json()

### DIFF
--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -642,7 +642,7 @@ def get_top_crypto():
                                                                strip("+").\
                                                                replace(",", "")))
     del df["52 Week Range"]
-    del df["1 Day Chart"]
+    del df["Day Chart"]
     
     fields_to_change = [x for x in df.columns.tolist() if "Volume" in x \
                         or x == "Market Cap" or x == "Circulating Supply"]

--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -5,6 +5,15 @@ import io
 import re
 import json
 import datetime
+# Needed for decrypting
+import base64
+import hashlib
+# Need to install pycryptodome package
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
+# For pretty print
+from pprint import pp
+
 
 try:
     from requests_html import HTMLSession
@@ -364,28 +373,94 @@ def get_stats_valuation(ticker, headers = {'User-agent': 'Mozilla/5.0'}):
     return table
 
 
+def _decrypt_yblob_aes(data):
+    '''From pydata/pandas-datareader PR#953 - https://github.com/pydata/pandas-datareader/pull/953/commits/ea66d6b981554f9d0262038aef2106dda7138316 '''
+    encrypted_stores = data['context']['dispatcher']['stores']
+    _cs = data["_cs"]
+    _cr = data["_cr"]
 
+    _cr = b"".join(int.to_bytes(i, length=4, byteorder="big", signed=True) for i in json.loads(_cr)["words"])
+    password = hashlib.pbkdf2_hmac("sha1", _cs.encode("utf8"), _cr, 1, dklen=32).hex()
 
+    encrypted_stores = base64.b64decode(encrypted_stores)
+    assert encrypted_stores[0:8] == b"Salted__"
+    salt = encrypted_stores[8:16]
+    encrypted_stores = encrypted_stores[16:]
+
+    def EVPKDF(
+            password,
+            salt,
+            keySize=32,
+            ivSize=16,
+            iterations=1,
+            hashAlgorithm="md5",
+    ) -> tuple:
+        """OpenSSL EVP Key Derivation Function
+        Args:
+            password (Union[str, bytes, bytearray]): Password to generate key from.
+            salt (Union[bytes, bytearray]): Salt to use.
+            keySize (int, optional): Output key length in bytes. Defaults to 32.
+            ivSize (int, optional): Output Initialization Vector (IV) length in bytes. Defaults to 16.
+            iterations (int, optional): Number of iterations to perform. Defaults to 1.
+            hashAlgorithm (str, optional): Hash algorithm to use for the KDF. Defaults to 'md5'.
+        Returns:
+            key, iv: Derived key and Initialization Vector (IV) bytes.
+        Taken from: https://gist.github.com/rafiibrahim8/0cd0f8c46896cafef6486cb1a50a16d3
+        OpenSSL original code: https://github.com/openssl/openssl/blob/master/crypto/evp/evp_key.c#L78
+        """
+
+        assert iterations > 0, "Iterations can not be less than 1."
+
+        if isinstance(password, str):
+            password = password.encode("utf-8")
+
+        final_length = keySize + ivSize
+        key_iv = b""
+        block = None
+
+        while len(key_iv) < final_length:
+            hasher = hashlib.new(hashAlgorithm)
+            if block:
+                hasher.update(block)
+            hasher.update(password)
+            hasher.update(salt)
+            block = hasher.digest()
+            for _ in range(1, iterations):
+                block = hashlib.new(hashAlgorithm, block).digest()
+            key_iv += block
+
+        key, iv = key_iv[:keySize], key_iv[keySize:final_length]
+        return key, iv
+
+    key, iv = EVPKDF(password, salt, keySize=32, ivSize=16, iterations=1, hashAlgorithm="md5")
+
+    cipher = AES.new(key, AES.MODE_CBC, iv=iv)
+    plaintext = cipher.decrypt(encrypted_stores)
+    plaintext = unpad(plaintext, 16, style="pkcs7")
+    decoded_stores = json.loads(plaintext)
+    return decoded_stores
 
 def _parse_json(url, headers = {'User-agent': 'Mozilla/5.0'}):
+
     html = requests.get(url=url, headers = headers).text
 
-    json_str = html.split('root.App.main =')[1].split(
-        '(this)')[0].split(';\n}')[0].strip()
-    
+    json_str = html.split('root.App.main =')[1].split('(this)')[0].split(';\n}')[0].strip()
+
     try:
-        data = json.loads(json_str)[
-            'context']['dispatcher']['stores']['QuoteSummaryStore']
+        data = json.loads(json_str)
+        #print("type of json_str :", type(data))
+        unencrypted_stores = _decrypt_yblob_aes(data)
+        json_info = unencrypted_stores['QuoteSummaryStore']
+        #print("json_info :", json_info)
     except:
         return '{}'
-    else:
+    #else:
         # return data
-        new_data = json.dumps(data).replace('{}', 'null')
-        new_data = re.sub(r'\{[\'|\"]raw[\'|\"]:(.*?),(.*?)\}', r'\1', new_data)
-
-        json_info = json.loads(new_data)
-
-        return json_info
+        #new_data = json.dumps(data).replace('{}', 'null')
+        #new_data = re.sub(r'\{[\'|\"]raw[\'|\"]:(.*?),(.*?)\}', r'\1', new_data)
+        #json_info = json.loads(new_data)
+        #print("json info :", json_info)
+    return json_info
 
 
 def _parse_table(json_info):
@@ -795,7 +870,7 @@ def get_earnings(ticker):
     
     result["quarterly_revenue_earnings"] = pd.DataFrame.from_dict(temp["financialsChart"]["quarterly"])
     
-    return result
+    return (pp(result))
 
 
 


### PR DESCRIPTION
Yahoo finance is now encrypting json payload returned in root.App,main object (['context']['dispatcher']['stores']) using AES encryption. This was causing parsing error in _parse_json() of yahoo_fin. 

Added _decrypt_yblob_aes() method based on code from pydata/pandas-datareader PR#953 - From pydata/pandas-datareader PR#953 - 'https://github.com/pydata/pandas-datareader/pull/953/commits/ea66d6b981554f9d0262038aef2106dda7138316'