### PR TITLE
fix broken functions caused by changes to the yahoo api

### DIFF
--- a/yahoo_fin.egg-info/requires.txt
+++ b/yahoo_fin.egg-info/requires.txt
@@ -2,3 +2,6 @@ requests_html
 feedparser
 requests
 pandas
+pycryptodome
+beautifulsoup4==4.11.1
+bs4==0.0.2

--- a/yahoo_fin/stock_info.py
+++ b/yahoo_fin/stock_info.py
@@ -891,7 +891,7 @@ def get_earnings(ticker):
     
     result["quarterly_revenue_earnings"] = pd.DataFrame.from_dict(temp["financialsChart"]["quarterly"])
     
-    return (pp(result))
+    return result
 
 
 


### PR DESCRIPTION
This pull request fixes the get_income_statement, get_balance_sheet, get_cash_flow, get_financials, get_earnings, get_company_info, and get_company_officer methods. I found that changes to the yahoo api (html/json we are getting back from yahoo) were causing _parse_json and _parse_table to break leading to the functions above failing as well when calling them as an end user of yahoo_fin.